### PR TITLE
Incorporate internal EMC Isilon changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,51 @@
-This is a fork of the vSPC.py project [1]. Most of vSPC.py, as you can
-see, was written by Zach Loafman at EMC Isilon. This repository includes
-all active development and should be considered authoritative.
-Changes introduced since the fork include SSL support for connections
-between ESX hosts and vSPC.py, console activity logging, and some other
-minor improvements.
+# Overview
 
-## Requirements ##
+vSPC.py is a Virtual Serial Port Concentrator (also known as a virtual
+serial port proxy) that makes use of the
+[VMware telnet extensions](http://www.vmware.com/support/developer/vc-sdk/visdk41pubs/vsp41_usingproxy_virtual_serial_ports.pdf).
+
+# Features
+
+- Point any number of virtual serial ports to a single vSPC.py server
+(great for cloned VMs)
+- Multiplexed client connects: Multiple entities can interact with the
+same console. Also allows for gdb connections while monitoring the console.
+- Port mappings are sticky - port number will stay constant as long as
+the VM or a client is connected, with a set expiration timer after all
+connections terminate
+- vMotion is fully supported
+- Query interface allows you to see VM name, UUID, port mappings on the
+vSPC.py server
+- Clients can connect using standard telnet, binary mode is negotiated
+automatically
+
+# Lineage
+
+This began as is a fork of the
+[vSPC.py project hosted at SourceForge](http://sourceforge.net/p/vspcpy/home/Home/)
+written by Zach Loafman while at EMC Isilon. It languished until it was
+forked by [Kevan Carstensen on github](https://github.com/isnotajoke) and
+extensively refactored and enhanced. Changes introduced since the SF fork
+include SSL support for connections between ESX hosts and vSPC.py, console
+activity logging, and some other minor improvements.
+
+Kevan's fork was re-forked by EMC Isilon to address bugs as we began using
+it heavily in our environment once more.
+
+# Requirements
 
 Python 2.5 or better is required, due to use of the 'with' statement and
-other syntax that was introduced in Python 2.5.
+other syntax that was introduced in Python 2.5. It's being developed against
+Python 2.6, however, since that's the currently-shipping version for
+RHEL/CentOS 6.
 
 Due to the use of epoll in the server implementation, Linux is required.
 There may be other issues associated with using vSPC.py on other OSs, as
 large parts of vSPC.py were only developed & tested on Linux.
 
-## Configuring VMs to connect to the concentrator ##
+VMWare ESXi 4.1 through 5.5 are supported.
+
+# Configuring VMs to connect to the concentrator
 
 In order to configure a VM to use the virtual serial port concentrator,
 you must be running ESXi 4.1+. You must also have a software license
@@ -41,7 +72,7 @@ which should specify telnets instead of telnet. For this to work
 correctly, you'll also need to launch the server with the --ssl, --cert,
 and possibly --key options.
 
-## Running the Concentrator ##
+# Running the Concentrator
 
 You run the concentrator through the vSPCServer program. The vSPCServer
 program is configurable with a number of options, documented below and
@@ -78,15 +109,15 @@ the VM is connected, and even after this condition is no longer met, the
 mapping is retained for --vm-expire-time seconds (default 24*3600, or
 one day).
 
-The backend of vSPCServer serves three major purposes: (a) On initial
-load, all port mappings are retrieved from the backend. The main thread
-maintains the port mappings after initial load, but the backend is
-responsible for setting the initial map. (This design was chosen to
-avoid blocking on the backend when a new VM connects.) (b) The backend
-serves all admin connections (because it has full knowledge of the
-mappings), (c) The backend can fire off customizable hooks as VMs come
-and go, allowing for persistence, or database tracking, or
-whatever.
+The backend of vSPCServer serves three major purposes:
+- On initial load, all port mappings are retrieved from the backend.
+The main thread maintains the port mappings after initial load, but the
+backend is responsible for setting the initial map. (This design was
+chosen to avoid blocking on the backend when a new VM connects.)
+- The backend serves all admin connections (because it has full knowledge
+of the mappings)
+- The backend can fire off customizable hooks as VMs come and go, allowing
+for persistence, or database tracking, or whatever.
 
 By default, vSPCServer uses the "Memory" backend, which really just
 means that no initial mappings are loaded on startup and all state is
@@ -97,23 +128,28 @@ If '--backend Foo' is given but no builtin backend Foo exists, vSPC.py
 tries to import module vSPCBackendFoo, looking for class vSPCBackendFoo.
 Use --help with the desired --backend for help using that backend.
 
-## Building the distribution ##
+# Building the distribution
 
-# source distribution #
+source distribution
+```
 /path/to/your/python setup.py sdist
+```
 
-# binary distribution #
+binary distribution
+```
 /path/to/your/python setup.py bdist
+```
 
-# build rpm
-# make source dist and then:
+build rpm
+```
+/path/to/your/python setup.py sdist
 rpmbuild -ta vSPC-<version>.tar.gz
+```
 
-## Authors ##
+# Authors
 
 - Zach Loafman (initial implementation)
 - Kevan Carstensen (SSL support, logging backend, lazy client connections to VMs, internal work necessary to support lazy connections to VMs)
 - Dave Johnson (fixes for missing getopt modules and missing shelf.sync() calls)
 - Fabien Wernli (add options to configure listen interface, fix broken -f option, packaging improvements)
-
-[1] http://sourceforge.net/p/vspcpy/home/Home/
+- Casey Peel (simplified backend argument parsing, fix connection leaks, and improved logging performance)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 This is a fork of the vSPC.py project [1]. Most of vSPC.py, as you can
-see, was written by Zach Loafman. I made this temporary repository to
-hold some changes I made to vSPC.py until they get accepted upstream.
-These changes include SSL support for connections between ESX hosts and
-vSPC.py, console activity logging, and some other minor improvements.
+see, was written by Zach Loafman at EMC Isilon. This repository includes
+all active development and should be considered authoritative.
+Changes introduced since the fork include SSL support for connections
+between ESX hosts and vSPC.py, console activity logging, and some other
+minor improvements.
 
 ## Requirements ##
 
@@ -90,14 +91,11 @@ whatever.
 By default, vSPCServer uses the "Memory" backend, which really just
 means that no initial mappings are loaded on startup and all state is
 retained in memory alone. The other builtin backend is the "File"
-backend, which can be configured like so: --backend File --backend-args
-'-f /tmp/vSPC'.  As a convenience, this same configuration can be
-accomplished using the top level parameter -f or --persist-file, i.e.
-'-f /tmp/vSPC' is synonymous with the previous set of arguments.
+backend, which can be configured like so: --backend File -f /tmp/vSPC.
 
 If '--backend Foo' is given but no builtin backend Foo exists, vSPC.py
 tries to import module vSPCBackendFoo, looking for class vSPCBackendFoo.
-See --backend-help for programming details.
+Use --help with the desired --backend for help using that backend.
 
 ## Building the distribution ##
 

--- a/lib/admin.py
+++ b/lib/admin.py
@@ -35,9 +35,8 @@ import os
 import cPickle as pickle
 import socket
 import sys
-import termios
 
-from telnetlib import BINARY, ECHO, SGA
+from telnetlib import BINARY, SGA
 
 from telnet import TelnetServer
 from poll import Poller

--- a/lib/admin.py
+++ b/lib/admin.py
@@ -32,7 +32,7 @@
 import fcntl
 import logging
 import os
-import pickle
+import cPickle as pickle
 import socket
 import sys
 import termios

--- a/lib/admin.py
+++ b/lib/admin.py
@@ -29,9 +29,6 @@
 # authors and should not be interpreted as representing official policies, either expressed
 # or implied, of <copyright holder>.
 
-import fcntl
-import logging
-import os
 import cPickle as pickle
 import socket
 import sys

--- a/lib/backend.py
+++ b/lib/backend.py
@@ -402,12 +402,10 @@ class vSPCBackendLogging(vSPCBackendMemory):
         self.scrollback_limit = 200
 
 
-    def setup(self, args):
-        parsed_args = self.parse_args(args)
-
-        self.logdir = parsed_args.logdir
-        self.prefix = parsed_args.prefix
-        self.mode  = parsed_args.mode
+    def setup(self, options):
+        self.logdir = options.logdir
+        self.prefix = options.prefix
+        self.mode  = options.mode
 
         # register for SIGHUP, so we know when to reload logfiles.
         signal.signal(signal.SIGHUP, self.handle_sighup)

--- a/lib/backend.py
+++ b/lib/backend.py
@@ -35,6 +35,7 @@ import optparse
 import os
 import cPickle as pickle
 import signal
+import socket
 import string
 import sys
 import threading
@@ -167,9 +168,16 @@ class vSPCBackendMemory:
         vm = None
         with self.observed_vms_lock:
             if uuid in self.observed_vms: vm = self.observed_vms[uuid]
-        if vm is not None:
-            with vm.modification_lock:
-                self.maybe_unlock_vm(vm, sock.fileno())
+
+        # socket manipulations may fail if there was no socket successfully
+        # created but we're still doing client cleanup
+        try:
+            if vm is not None:
+                with vm.modification_lock:
+                    self.maybe_unlock_vm(vm, sock.fileno())
+            sock.close()
+        except socket.error:
+            pass
 
     def notify_vm_del(self, uuid):
         self.observer_queue.put(lambda: self.vm_del(uuid))

--- a/lib/backend.py
+++ b/lib/backend.py
@@ -33,7 +33,7 @@ import getopt
 import logging
 import optparse
 import os
-import pickle
+import cPickle as pickle
 import signal
 import string
 import sys

--- a/lib/backend.py
+++ b/lib/backend.py
@@ -92,6 +92,9 @@ class vSPCBackendMemory:
         self.observer_thread = self._start_thread(self.observer_run)
         self.hook_thread = self._start_thread(self.hook_run)
 
+    def shutdown(self):
+        pass
+
     def _queue_run(self, queue):
         while True:
             try:
@@ -360,6 +363,9 @@ class vSPCBackendFile(vSPCBackendMemory):
 
         self.shelf = shelve.open(options.filename)
 
+    def shutdown(self):
+        self.shelf.close()
+
     def vm_hook(self, uuid, name, port):
         self.shelf[uuid] = { P_UUID : uuid, P_NAME : name, P_PORT : port }
         self.shelf.sync()
@@ -398,6 +404,10 @@ class vSPCBackendLogging(vSPCBackendMemory):
         # How many scrollback lines to keep for each VM.
         self.scrollback_limit = options.context
 
+    def shutdown(self):
+        for k, f in self.logfiles.iteritems():
+            f.close()
+
     def add_scrollback(self, uuid, msg):
         msgs = self.scrollback.setdefault(uuid, "")
         msgs += msg
@@ -428,7 +438,6 @@ class vSPCBackendLogging(vSPCBackendMemory):
         # XXX: Annoying; it would be nicer if OptionParser would print
         # out a more verbose message upon encountering unrecognized
         # arguments
-        u = "%prog ...--backend-args='[ [ (-l | --logdir) logdir ] [ (-p | --prefix) prefix ] [ (-m | --mode) mode ]'"
         group.add_option("-l", "--logdir", type='string',
                          action='store', default="/var/log/consoles",
                          help='Directory in which log files are written')

--- a/lib/server.py
+++ b/lib/server.py
@@ -222,8 +222,7 @@ class vSPC(Poller, VMExtHandler):
         self.add_reader(client, self.queue_new_client_data)
         vm.clients.append(client)
 
-        logging.info('Client connected to %s (uuid %s), '
-                     '%d active clients to vm',
+        logging.info('Client connected to %s (uuid %s), %d active clients',
                      vm.name, vm.uuid, len(vm.clients))
 
     def queue_new_client_connection(self, vm):
@@ -239,8 +238,7 @@ class vSPC(Poller, VMExtHandler):
 
     def abort_vm_connection(self, vt):
         if vt.uuid:
-            logging.info('VM %s (uuid %s) disconnected',
-                         vt.name, vt.uuid)
+            logging.info('VM %s (uuid %s) disconnected', vt.name, vt.uuid)
             if vt.uuid in self.vms:
                 if vt in self.vms[vt.uuid].vts:
                     self.vms[vt.uuid].vts.remove(vt)
@@ -389,8 +387,7 @@ class vSPC(Poller, VMExtHandler):
         vm = self.vms[vt.uuid]
         vm.vts.append(vt)
 
-        logging.info('VM %s (uuid %s) reconnected (maybe vmotion), %d active',
-                      vm.name, vm.uuid, len(vm.vts))
+        logging.info('VM %s (uuid %s) reconnected/vmotion', vm.name, vm.uuid)
 
     def handle_vm_name(self, vt):
         if not self.vms.has_key(vt.uuid):

--- a/lib/server.py
+++ b/lib/server.py
@@ -163,7 +163,7 @@ class vSPC(Poller, VMExtHandler):
                 client_connections += len(vm.clients)
             except KeyError:
                 # Other processes may be changing self.vms under us so don't
-                # die if the uuid doesn't exist when we get to it.
+                # die if the vms record doesn't exist when we get to it.
                 pass
 
         logging.debug("Current open connection count: "

--- a/lib/server.py
+++ b/lib/server.py
@@ -155,8 +155,14 @@ class vSPC(Poller, VMExtHandler):
         sock.setblocking(0)
         sock.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, 1)
 
-        client = self.Client(sock)
-        client.uuid = vm.uuid
+        try:
+            client = self.Client(sock)
+            client.uuid = vm.uuid
+        except socket.error, err:
+            # If there was a socket error on initialization, capture the
+            # exception to avoid logging a traceback.
+            logging.debug("uninitialized client socket error")
+            return
 
         self.add_reader(client, self.queue_new_client_data)
         vm.clients.append(client)

--- a/lib/server.py
+++ b/lib/server.py
@@ -157,9 +157,14 @@ class vSPC(Poller, VMExtHandler):
 
         vm_connections = len(self.vms)
         client_connections = 0
-        for uuid in self.vms:
-            vm = self.vms[uuid]
-            client_connections += len(vm.clients)
+        for uuid in self.vms.keys():
+            try:
+                vm = self.vms[uuid]
+                client_connections += len(vm.clients)
+            except KeyError:
+                # Other processes may be changing self.vms under us so don't
+                # die if the uuid doesn't exist when we get to it.
+                pass
 
         logging.debug("Current open connection count: "
                 "%d vms (%d orphans), %d clients", vm_connections,

--- a/lib/server.py
+++ b/lib/server.py
@@ -42,7 +42,7 @@ import Queue
 
 from telnetlib import BINARY, SGA, ECHO
 
-from vSPC.poll import Poller, Selector
+from vSPC.poll import Poller
 from vSPC.telnet import TelnetServer, VMTelnetServer, VMExtHandler, hexdump
 
 LISTEN_BACKLOG = 5
@@ -52,7 +52,7 @@ def openport(port, iface="", use_ssl=False, ssl_cert=None, ssl_key=None):
     if use_ssl:
         sock = ssl.wrap_socket(sock, keyfile=ssl_key, certfile=ssl_cert)
     sock.setblocking(0)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1);
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.bind((iface, port))
     sock.listen(LISTEN_BACKLOG)
     return sock
@@ -87,8 +87,8 @@ class vSPC(Poller, VMExtHandler):
         self.proxy_port = proxy_port
         self.admin_port = admin_port
         self.vm_iface = vm_iface
-        self.proxy_iface = proxy_iface;
-        self.admin_iface = admin_iface;
+        self.proxy_iface = proxy_iface
+        self.admin_iface = admin_iface
         if not vm_port_start: # account for falsey things, not just None
             vm_port_start = None
         self.vm_port_next = vm_port_start
@@ -135,8 +135,13 @@ class vSPC(Poller, VMExtHandler):
     def new_vm_connection(self, sock):
         sock.setblocking(0)
         sock.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, 1)
-        vt = VMTelnetServer(sock, handler = self)
-        self.add_reader(vt, self.queue_new_vm_data)
+        try:
+            vt = VMTelnetServer(sock, handler = self)
+            self.add_reader(vt, self.queue_new_vm_data)
+        except socket.error, err:
+            # If there was a socket error on initialization, capture the
+            # exception to avoid logging a traceback.
+            logging.debug("uninitialized VM socket error")
 
     def queue_new_vm_connection(self, listener):
         try:
@@ -156,8 +161,8 @@ class vSPC(Poller, VMExtHandler):
         self.add_reader(client, self.queue_new_client_data)
         vm.clients.append(client)
 
-        logging.debug('uuid %s new client, %d active clients'
-                      % (client.uuid, len(vm.clients)))
+        logging.debug('uuid %s new client, %d active clients',
+                      client.uuid, len(vm.clients))
 
     def queue_new_client_connection(self, vm):
         sock = vm.listener.accept()[0]
@@ -165,12 +170,11 @@ class vSPC(Poller, VMExtHandler):
 
     def abort_vm_connection(self, vt):
         if vt.uuid and vt in self.vms[vt.uuid].vts:
-            logging.debug('uuid %s VM socket closed' % vt.uuid)
+            logging.debug('uuid %s VM socket closed', vt.uuid)
             self.vms[vt.uuid].vts.remove(vt)
             self.stamp_orphan(self.vms[vt.uuid])
         else:
             logging.debug('unidentified VM socket closed')
-        self.delete_stream(vt)
         vt.close()
 
     def new_vm_data(self, vt):
@@ -206,7 +210,7 @@ class vSPC(Poller, VMExtHandler):
             self.add_reader(vt, self.queue_new_vm_data)
             return
 
-        # logging.debug('new_vm_data %s: %s' % (vt.uuid, repr(s)))
+        # logging.debug('new_vm_data %s: %s', vt.uuid, repr(s))
         self.backend.notify_vm_msg(vt.uuid, vt.name, s)
 
         clients = self.vms[vt.uuid].clients[:]
@@ -214,7 +218,7 @@ class vSPC(Poller, VMExtHandler):
             try:
                 self.send_buffered(cl, s)
             except (EOFError, IOError, socket.error), e:
-                logging.debug('cl.socket send error: %s' % (str(e)))
+                logging.debug('cl.socket send error: %s', str(e))
                 self.abort_client_connection(cl)
         self.add_reader(vt, self.queue_new_vm_data)
 
@@ -224,12 +228,11 @@ class vSPC(Poller, VMExtHandler):
         self.task_queue.put(lambda: self.new_vm_data(vt))
 
     def abort_client_connection(self, client):
-        logging.debug('uuid %s client socket closed, %d active clients' %
-                      (client.uuid, len(self.vms[client.uuid].clients)-1))
+        logging.debug('uuid %s client socket closed, %d active clients',
+                      client.uuid, len(self.vms[client.uuid].clients)-1)
         if client in self.vms[client.uuid].clients:
             self.vms[client.uuid].clients.remove(client)
             self.stamp_orphan(self.vms[client.uuid])
-        self.delete_stream(client)
         self.backend.notify_client_del(client.sock, client.uuid)
 
     def new_client_data(self, client):
@@ -260,13 +263,13 @@ class vSPC(Poller, VMExtHandler):
             self.add_reader(client, self.queue_new_client_data)
             return
 
-        # logging.debug('new_client_data %s: %s' % (client.uuid, repr(s)))
+        # logging.debug('new_client_data %s: %s', client.uuid, repr(s))
 
         for vt in self.vms[client.uuid].vts:
             try:
                 self.send_buffered(vt, s)
             except (EOFError, IOError, socket.error), e:
-                logging.debug('cl.socket send error: %s' % (str(e)))
+                logging.debug('cl.socket send error: %s', str(e))
         self.add_reader(client, self.queue_new_client_data)
 
     def queue_new_client_data(self, client):
@@ -284,9 +287,9 @@ class vSPC(Poller, VMExtHandler):
         if not port:
             self.backend.notify_vm(vm.uuid, vm.name, vm.port)
 
-        logging.debug('%s:%s connected' % (vm.uuid, repr(vm.name)))
+        logging.debug('%s:%s connected', vm.uuid, repr(vm.name))
         if vm.port is not None:
-            logging.debug("listening on port %d" % vm.port)
+            logging.debug("listening on port %d", vm.port)
 
         # The clock is always ticking
         self.stamp_orphan(vm)
@@ -311,8 +314,8 @@ class vSPC(Poller, VMExtHandler):
         vm = self.vms[vt.uuid]
         vm.vts.append(vt)
 
-        logging.debug('uuid %s VM reconnect, %d active' %
-                      (vm.uuid, len(vm.vts)))
+        logging.debug('uuid %s VM reconnect, %d active',
+                      vm.uuid, len(vm.vts))
 
     def handle_vm_name(self, vt):
         if not self.vms.has_key(vt.uuid):
@@ -340,17 +343,17 @@ class vSPC(Poller, VMExtHandler):
 
     def handle_vmotion_peer(self, vt, data):
         if not self.vmotions.has_key(data):
-            logging.debug('peer cookie %s doesn\'t exist' % hexdump(data))
+            logging.debug('peer cookie %s doesn\'t exist', hexdump(data))
             return False
 
-        logging.debug('peer cookie %s maps to uuid %s' %
-                      (hexdump(data), self.vmotions[data]))
+        logging.debug('peer cookie %s maps to uuid %s',
+                      hexdump(data), self.vmotions[data])
 
         peer_uuid = self.vmotions[data]
         if vt.uuid:
             vm = self.vms[vt.uuid]
             if vm.uuid != peer_uuid:
-                logging.debug('peer uuid %s != other uuid %s' % hexdump(data))
+                logging.debug('peer uuid %s != other uuid %s', hexdump(data))
                 return False
             return True # vt already in place
         else:
@@ -361,13 +364,13 @@ class vSPC(Poller, VMExtHandler):
         return True
 
     def handle_vmotion_complete(self, vt):
-        logging.debug('uuid %s vmotion complete' % vt.uuid)
+        logging.debug('uuid %s vmotion complete', vt.uuid)
         vm = self.vms[vt.uuid]
         del self.vmotions[vm.vmotion]
         vm.vmotion = None
 
     def handle_vmotion_abort(self, vt):
-        logging.debug('uuid %s vmotion abort' % vt.uuid)
+        logging.debug('uuid %s vmotion abort', vt.uuid)
         vm = self.vms[vt.uuid]
         if vm.vmotion:
             del self.vmotions[vm.vmotion]
@@ -399,8 +402,8 @@ class vSPC(Poller, VMExtHandler):
             self.add_reader(client, self.queue_new_client_data)
         vm.clients.append(client)
 
-        logging.debug('uuid %s new client, %d active clients'
-                      % (client.uuid, len(vm.clients)))
+        logging.debug('uuid %s new client, %d active clients',
+                      client.uuid, len(vm.clients))
 
     def queue_new_admin_client_connection(self, sock, uuid, readonly):
         self.task_queue.put(lambda: self.new_admin_client_connection(sock, uuid, readonly))
@@ -421,9 +424,9 @@ class vSPC(Poller, VMExtHandler):
             elif vm.last_time + self.vm_expire_time > t:
                 continue
 
-            logging.debug('expired VM with uuid %s' % uuid)
+            logging.debug('expired VM with uuid %s', uuid)
             if vm.port is not None:
-                logging.debug(", port %d" % vm.port)
+                logging.debug(", port %d", vm.port)
             self.backend.notify_vm_del(vm.uuid)
 
             self.delete_stream(vm)
@@ -464,10 +467,12 @@ class vSPC(Poller, VMExtHandler):
             self.new_vm(uuid = vm.uuid, name = vm.name, port = vm.port)
 
     def run(self):
-        logging.info('Starting vSPC on proxy iface %s port %d, admin iface %s port %d' %
-                     (self.proxy_iface, self.proxy_port, self.admin_iface, self.admin_port))
+        logging.info('Starting vSPC on proxy iface %s port %d, admin iface %s '
+                     'port %d', self.proxy_iface, self.proxy_port,
+                     self.admin_iface, self.admin_port)
         if self.vm_port_next is not None:
-            logging.info("Allocating VM ports starting at %d on interface %s" % (self.vm_port_next, self.vm_iface) )
+            logging.info("Allocating VM ports starting at %d on interface %s",
+                         self.vm_port_next, self.vm_iface)
 
         self.create_old_vms(self.backend.get_observed_vms())
 

--- a/lib/server.py
+++ b/lib/server.py
@@ -175,10 +175,12 @@ class vSPC(Poller, VMExtHandler):
         self.task_queue.put(lambda: self.new_client_connection(sock, vm))
 
     def abort_vm_connection(self, vt):
-        if vt.uuid and vt in self.vms[vt.uuid].vts:
+        if vt.uuid:
             logging.debug('uuid %s VM socket closed', vt.uuid)
-            self.vms[vt.uuid].vts.remove(vt)
-            self.stamp_orphan(self.vms[vt.uuid])
+            if vt.uuid in self.vms:
+                if vt in self.vms[vt.uuid].vts:
+                    self.vms[vt.uuid].vts.remove(vt)
+                self.stamp_orphan(self.vms[vt.uuid])
         else:
             logging.debug('unidentified VM socket closed')
         vt.close()

--- a/lib/telnet.py
+++ b/lib/telnet.py
@@ -29,7 +29,7 @@
 # authors and should not be interpreted as representing official policies, either expressed
 # or implied, of <copyright holder>.
 
-BASENAME='vSPC.py'
+BASENAME = 'vSPC.py'
 
 import logging
 import struct
@@ -41,7 +41,7 @@ from telnetlib import IAC,DO,DONT,WILL,WONT,BINARY,ECHO,SGA,SB,SE,NOOPT,theNULL
 # How long to wait for an option response. Any option response resets
 # the counter. This is mainly to deal with "raw" connections (like
 # gdb) that don't negotiate telnet options at all.
-UNACK_TIMEOUT=0.5
+UNACK_TIMEOUT = 0.5
 
 VMWARE_EXT = chr(232) # VMWARE-TELNET-EXT
 
@@ -97,7 +97,7 @@ telnet client. This port is intended for VMware connections only.\r
 '''
 
 def hexdump(data):
-    return reduce(lambda x,y: x + ('%x' % ord(y)), data, '')
+    return reduce(lambda x, y: x + ('%x' % ord(y)), data, '')
 
 class FixedTelnet(Telnet):
     '''
@@ -198,11 +198,11 @@ class TelnetServer(FixedTelnet):
         self.send_buffer = ''
 
         for opt in self.server_opts:
-            logging.debug("sending WILL %d" % ord(opt))
+            logging.debug("sending WILL %d", ord(opt))
             self._send_cmd(WILL + opt)
             self.unacked.append((WILL, opt))
         for opt in self.client_opts:
-            logging.debug("sending DO %d" % ord(opt))
+            logging.debug("sending DO %d", ord(opt))
             self._send_cmd(DO + opt)
             self.unacked.append((DO, opt))
 
@@ -212,7 +212,7 @@ class TelnetServer(FixedTelnet):
     def _option_callback(self, sock, cmd, opt):
         if cmd in (DO, DONT):
             if opt not in self.server_opts:
-                logging.debug("client wants us to %d, sending WONT" % ord(opt))
+                logging.debug("client wants us to %d, sending WONT", ord(opt))
                 self._send_cmd(WONT + opt)
                 return
 
@@ -223,20 +223,20 @@ class TelnetServer(FixedTelnet):
                 self.unacked.remove((WILL, opt))
 
             if cmd == DONT:
-                logging.debug("client doesn't want us to %d" % ord(opt))
+                logging.debug("client doesn't want us to %d", ord(opt))
                 try:
                     self.server_opts_accepted.remove(opt)
                 except ValueError:
                     pass
             else:
-                logging.debug("client says we should %d" % ord(opt))
+                logging.debug("client says we should %d", ord(opt))
 
             if not msg_is_reply:
                 # Remind client that we want this option
                 self._send_cmd(WILL + opt)
         elif cmd in (WILL, WONT):
             if opt not in self.client_opts:
-                logging.debug("client wants to %d, sending DONT" % ord(opt))
+                logging.debug("client wants to %d, sending DONT", ord(opt))
                 self._send_cmd(DONT + opt)
                 return
 
@@ -247,13 +247,13 @@ class TelnetServer(FixedTelnet):
                 self.unacked.remove((DO, opt))
 
             if cmd == WONT:
-                logging.debug("client won't %d" % ord(opt))
+                logging.debug("client won't %d", ord(opt))
                 try:
                     self.client_opts_accepted.remove(opt)
                 except ValueError:
                     pass
             else:
-                logging.debug("client will %d" % ord(opt))
+                logging.debug("client will %d", ord(opt))
 
             if not msg_is_reply:
                 # Remind client that we want this option
@@ -261,7 +261,7 @@ class TelnetServer(FixedTelnet):
         elif cmd == SB:
             pass # Don't log this, caller is processing
         else:
-            logging.debug("cmd %d %s" % (ord(cmd), opt))
+            logging.debug("cmd %d %s", ord(cmd), opt)
 
     def process_available(self):
         """Process all data, but don't take anything off the cooked queue.
@@ -275,12 +275,12 @@ class TelnetServer(FixedTelnet):
     def negotiation_done(self):
         self.process_available()
         if self.unacked:
-            desc = map(lambda (x,y): (ord(x), ord(y)), self.unacked)
+            desc = map(lambda (x, y): (ord(x), ord(y)), self.unacked)
             if time.time() > self.last_ack + UNACK_TIMEOUT:
-                logging.debug("timeout waiting for commands %s" % desc)
+                logging.debug("timeout waiting for commands %s", desc)
                 self.unacked = []
             else:
-                logging.debug("still waiting for %s" % desc)
+                logging.debug("still waiting for %s", desc)
 
         return not self.unacked
 
@@ -328,37 +328,41 @@ class VMTelnetServer(TelnetServer):
         self.sock.sendall(IAC + SB + VMWARE_EXT + s + IAC + SE)
 
     def _handle_known_options(self, data):
-        logging.debug("client knows VM commands: %s" % map(ord, data))
+        logging.debug("client knows VM commands: %s", map(ord, data))
 
     def _handle_unknown_option(self, data):
-        logging.debug("client doesn't know VM command %d, dropping" % hexdump(data))
+        logging.debug("client doesn't know VM command %d, dropping",
+                      hexdump(data))
 
     def _handle_do_proxy(self, data):
         dir = 'client' if data[:1] == "C" else 'server'
         uri = data[1:]
-        logging.debug("client wants to proxy %s to %s" % (dir, uri))
+        logging.debug("client wants to proxy %s to %s", dir, uri)
         if dir == 'server' and uri == BASENAME:
             self._send_vmware(WILL_PROXY)
+            logging.debug("direction and uri are correct, will proxy")
         else:
             self._send_vmware(WONT_PROXY)
+            logging.error("client serial configuration incorrect (direction: "
+                "%s, uri: %s), will not proxy for this VM", dir, uri)
 
     def _handle_vmotion_begin(self, data):
         cookie = data + struct.pack("i", hash(self) & 0xFFFFFFFF)
 
         if self.handler.handle_vmotion_begin(self, cookie):
-            logging.debug("vMotion initiated: %s" % hexdump(cookie))
+            logging.debug("vMotion initiated: %s", hexdump(cookie))
             self._send_vmware(VMOTION_GOAHEAD + cookie)
         else:
-            logging.debug("vMotion denied: %s" % hexdump(cookie))
+            logging.debug("vMotion denied: %s", hexdump(cookie))
             self._send_vmware(VMOTION_NOTNOW + cookie)
 
     def _handle_vmotion_peer(self, cookie):
         if self.handler.handle_vmotion_peer(self, cookie):
-            logging.debug("vMotion peer: %s" % hexdump(cookie))
+            logging.debug("vMotion peer: %s", hexdump(cookie))
             self._send_vmware(VMOTION_PEER_OK + cookie)
         else:
             # There's no clear spec on rejecting this
-            logging.debug("vMotion peer rejected: %s" % hexdump(cookie))
+            logging.debug("vMotion peer rejected: %s", hexdump(cookie))
             self._send_vmware(UNKNOWN_SUBOPTION_RCVD_2 + VMOTION_PEER)
 
     def _handle_vmotion_complete(self, data):
@@ -374,7 +378,7 @@ class VMTelnetServer(TelnetServer):
             self.handler.handle_vc_uuid(self)
         elif self.uuid != data:
             logging.warn("conflicting uuids? "
-                         "old: %s, new: %s" % (self.uuid, data))
+                         "old: %s, new: %s", self.uuid, data)
             self.close()
 
     def _handle_vm_name(self, data):
@@ -418,8 +422,8 @@ class VMTelnetServer(TelnetServer):
                 self.unacked.remove((VMWARE_EXT, subcmd))
 
         if not handled:
-            logging.debug('VMware command %d (data %s) not handled' \
-                              % (ord(subcmd), hexdump(data)))
+            logging.debug('VMware command %d (data %s) not handled',
+                          ord(subcmd), hexdump(data))
             self._send_vmware(UNKNOWN_SUBOPTION_RCVD_2 + subcmd)
 
 class VMTelnetProxyClient(TelnetServer):
@@ -435,13 +439,13 @@ class VMTelnetProxyClient(TelnetServer):
         self.sock.sendall(IAC + SB + VMWARE_EXT + s + IAC + SE)
 
     def _handle_known_options(self, data):
-        logging.debug("client knows VM commands: %s" % map(ord, data))
+        logging.debug("client knows VM commands: %s", map(ord, data))
 
     def _handle_unknown_option(self, data):
-        logging.debug("client doesn't know VM command %d, dropping" % hexdump(data))
+        logging.debug("client doesn't know VM command %d, dropping", hexdump(data))
 
     def _handle_unknown_option_resp(self, data):
-        logging.debug("client doesn't know VM command %s, dropping" % hexdump(data))
+        logging.debug("client doesn't know VM command %s, dropping", hexdump(data))
 
     def _handle_get_vm_name(self, data):
         self._send_vmware(VM_NAME + self.vm_name)
@@ -450,10 +454,12 @@ class VMTelnetProxyClient(TelnetServer):
         self._send_vmware(VM_VC_UUID + self.vm_uuid)
 
     def _handle_do_proxy_will(self, data):
-        logging.debug("proxy will handle proxy request for vm %s (%s)" % (self.vm_name, self.vm_uuid))
+        logging.debug("proxy will handle proxy request for vm %s (%s)",
+                      self.vm_name, self.vm_uuid)
 
     def _handle_do_proxy_wont(self, data):
-        logging.debug("proxy won't handle proxy request for vm %s (%s)" % (self.vm_name, self.vm_uuid))
+        logging.debug("proxy won't handle proxy request for vm %s (%s)",
+                      self.vm_name, self.vm_uuid)
         # XXX: Consider more robust error handling here?
         self.close()
 
@@ -501,7 +507,7 @@ class VMTelnetProxyClient(TelnetServer):
                 self.unacked.remove((VMWARE_EXT, subcmd))
 
         if not handled:
-            logging.debug('VMware command %d (data %s) not handled' \
-                              % (ord(subcmd), hexdump(data)))
+            logging.debug('VMware command %d (data %s) not handled',
+                          ord(subcmd), hexdump(data))
             self._send_vmware(UNKNOWN_SUBOPTION_RCVD_2 + subcmd)
 

--- a/lib/test.py
+++ b/lib/test.py
@@ -6,7 +6,6 @@ import logging
 import socket
 import sys
 import termios
-import time
 
 from poll import Poller
 from telnet import VMTelnetProxyClient
@@ -54,7 +53,7 @@ class FakeVMClient(Poller):
         except (EOFError, IOError, socket.error):
             self.quit()
 
-        logging.debug("got data from proxy: %s\n" % string_dump(s))
+        logging.debug("got data from proxy: %s\n", string_dump(s))
 
         if not s:
             # Could be option data, or something else that gets eaten by
@@ -78,7 +77,7 @@ class FakeVMClient(Poller):
             post_data = data[loc+1:]
             data = pre_data + self.process_escape_character() + post_data
 
-        logging.debug("got client data %s, sending to proxy" % string_dump(data))
+        logging.debug("got client data %s, sending to proxy", string_dump(data))
         self.send_buffered(self.tc, data)
 
     def process_escape_character(self):
@@ -107,7 +106,7 @@ class FakeVMClient(Poller):
         return ret
 
     def send_buffered(self, conn, data = ''):
-        logging.debug("sending data to proxy: %s" % string_dump(data))
+        logging.debug("sending data to proxy: %s", string_dump(data))
         if conn.send_buffered(data):
             self.add_writer(conn, self.send_buffered)
         else:

--- a/sample/vSPCBackendSample.py
+++ b/sample/vSPCBackendSample.py
@@ -51,11 +51,11 @@ import logging
 
 class vSPCBackendSample(vSPCBackendMemory):
     def vm_hook(self, uuid, name, port):
-        logging.debug("sample vm_hook: uuid: %s, name: %s, port: %s" %
-                      (uuid, name, port))
+        logging.debug("sample vm_hook: uuid: %s, name: %s, port: %s",
+                      uuid, name, port)
 
     def vm_del_hook(self, uuid):
-        logging.debug("sample vm_del_hook: uuid: %s" % uuid)
+        logging.debug("sample vm_del_hook: uuid: %s", uuid)
 
 
 

--- a/vSPCClient
+++ b/vSPCClient
@@ -52,7 +52,7 @@ def check_lock_mode(option, opt_str, value, parser):
             assert client_lock_mode == "free-for-all-fallback"
             parser.values.client_lock_mode = Q_LOCK_FFAR
 
-if __name__ == '__main__':
+def main():
     parser = OptionParser(usage="usage: %prog [options] [vm_name]",
                           description="Connect to the admin port of a running vSPC "
                                       "server. With no vm, this prints a list of VMs known to the "
@@ -91,4 +91,8 @@ if __name__ == '__main__':
     if len(args) == 1:
         vm_name = args[0]
 
-    sys.exit(do_query(options.remote_host, options.admin_port, vm_name, options.client_lock_mode))
+    return do_query(options.remote_host, options.admin_port, vm_name,
+                    options.client_lock_mode)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/vSPCServer
+++ b/vSPCServer
@@ -107,7 +107,22 @@ def get_backend_type(shortname):
     return backend_type
 
 if __name__=="__main__":
-    parser = OptionParser(description="Start Virtual Serial Port concentrator")
+    # pull out any specified backend so we can provide usage statements
+    # XXX this is a pseudo-hack
+    backend_type = "Memory"
+    if "--backend" in sys.argv:
+        try:
+            backend_type = sys.argv[sys.argv.index("--backend") + 1]
+        except:
+            pass
+
+    backend = get_backend_type(backend_type)()
+
+    # Now parse the command line
+    parser = OptionParser(
+        description="Start Virtual Serial Port concentrator",
+        conflict_handler="resolve")
+
     parser.add_option("-d", "--debug", action='store_true', default=False,
                       help="Debug mode (turns up logging and implies --stdout --no-fork)")
     parser.add_option("-a", "--admin-port", type='int', default=ADMIN_PORT,
@@ -131,10 +146,9 @@ if __name__=="__main__":
                       help="Don't daemonize")
     parser.add_option("--backend", dest='backend_type_name', default='Memory',
                       help="Name of custom backend class")
-    parser.add_option("--backend-args", dest='backend_args', default='',
-                      help='Arguments to custom backend')
-    parser.add_option("-f", "--persist-file", action='callback', type='string', callback=handle_persist_file,
-                      help="DBM file prefix to persist mappings to (.dat/.dir may follow")
+    parser.add_option("-f", "--persist-file", dest="persist_file",
+                      help="DBM file prefix to persist mappings to (.dat/.dir may follow. "
+                      "This is shorthand for --backend File --file FILE.")
     parser.add_option("--ssl", action='store_true', default=False,
                       help='Start SSL/TLS on connections to the proxy port')
     parser.add_option("--cert", default=None,
@@ -147,6 +161,9 @@ if __name__=="__main__":
                       help="The file to write the server's process ID to")
     parser.add_option("--no-vm-ports", action='store_false', dest='vm_port_start',
                       help='Whether to listen for incoming telnet connections to connected VMs.')
+
+    parser.add_option_group(backend.get_option_group(parser))
+
     (options, args) = parser.parse_args()
 
     logger = logging.getLogger('')
@@ -165,8 +182,13 @@ if __name__=="__main__":
     if options.ssl and not options.cert:
         parser.error("Must specify certificate in order to use SSL")
 
-    backend = get_backend_type(options.backend_type_name)()
-    backend.setup(options.backend_args)
+    try:
+        backend.setup(options)
+    except ValueError, err:
+        parser.error(err)
+        sys.exit(2)
+
+    backend.setup(options)
 
     if options.fork and not options.debug:
         daemonize()
@@ -178,7 +200,10 @@ if __name__=="__main__":
     try:
         backend.start()
 
-        vSPC(options.proxy_port, options.admin_port, options.proxy_iface, options.admin_iface, options.vm_port_start, options.vm_iface, options.vm_expire_time, backend, options.ssl, options.cert, options.key).run()
+        vSPC(options.proxy_port, options.admin_port, options.proxy_iface,
+            options.admin_iface, options.vm_port_start, options.vm_iface,
+            options.vm_expire_time, backend, options.ssl, options.cert,
+            options.key).run()
     except KeyboardInterrupt:
         logging.info("Shutdown requested on keyboard, exiting")
         sys.exit(0)

--- a/vSPCServer
+++ b/vSPCServer
@@ -206,7 +206,9 @@ if __name__=="__main__":
             options.key).run()
     except KeyboardInterrupt:
         logging.info("Shutdown requested on keyboard, exiting")
+        backend.shutdown()
         sys.exit(0)
     except Exception, e:
         logging.exception("Top level exception caught")
+        backend.shutdown()
         sys.exit(1)

--- a/vSPCServer
+++ b/vSPCServer
@@ -29,7 +29,7 @@ import logging
 import os
 import sys
 
-from optparse import OptionParser, OptionValueError
+from optparse import OptionParser
 
 from vSPC.server import vSPC
 from vSPC.backend import vSPCBackendMemory, vSPCBackendFile, vSPCBackendLogging
@@ -106,7 +106,7 @@ def get_backend_type(shortname):
 
     return backend_type
 
-if __name__=="__main__":
+def main():
     # pull out any specified backend so we can provide usage statements
     # XXX this is a pseudo-hack
     backend_type = "Memory"
@@ -207,8 +207,11 @@ if __name__=="__main__":
     except KeyboardInterrupt:
         logging.info("Shutdown requested on keyboard, exiting")
         backend.shutdown()
-        sys.exit(0)
+        return 0
     except Exception, e:
         logging.exception("Top level exception caught")
         backend.shutdown()
-        sys.exit(1)
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vSPCServer
+++ b/vSPCServer
@@ -81,11 +81,6 @@ def daemonize():
     os.chdir('/')
     os.umask(0)
 
-def handle_persist_file(option, opt_str, value, parser):
-    import pipes
-    parser.values.backend_type_name = "File"
-    parser.values.backend_args = "-f %s" % pipes.quote(value)
-
 def get_backend_type(shortname):
     name = "vSPCBackend" + shortname
     if globals().has_key(name):

--- a/vSPCServer
+++ b/vSPCServer
@@ -86,12 +86,22 @@ def get_backend_type(shortname):
     if globals().has_key(name):
         backend_type = globals()[name]
     else:
+        # Try importing assuming that PYTHONPATH has been set.
         try:
             module = __import__(name)
         except ImportError:
-            print "No builtin backend type %s found, no appropriate class " \
-                "file found (looking for %s.py)" % (shortname, name)
-            sys.exit(1)
+            # Try importing the backend assuming it has been placed in with
+            # the vSPC libraries.
+            try:
+                module_name = "vSPC.%s" % name
+                __import__(module_name)
+                module = sys.modules[module_name]
+            except ImportError:
+                print "No built-in backend type '%s' found. Error trying to " \
+                    "import backend (looking for %s.py). Either the module " \
+                    "wasn't on your PYTHONPATH or, if it was, there was an " \
+                    "error in the backend file." % (shortname, name)
+                sys.exit(1)
 
         try:
             backend_type = getattr(module, name)


### PR DESCRIPTION
This incorporates all of the internal changes that were done within EMC Isilon to the original vSPC.py into this fork, notably:
* Changing all logging to pass in arguments instead of doing string evaluation
* Revamping how backend argument parsing works
* Some pylint updates
* Other minor updates

During testing of this fork in our internal deployment, we found problems with how epoll was implemented and adjusted them based on perceived best-practices -- they now work for us.

Zach is no longer with EMC Isilon and is highly unlikely to be making changes to the SF repo. I recommend we make the isnotajoke repo the authoritative one (I've updated the README accordingly). I'm sure he'd be happy to update the SF repo to point to this one if I asked.